### PR TITLE
부산대  BE_정지민 6주차 (3단계)

### DIFF
--- a/src/main/java/gift/order/controller/OrderController.java
+++ b/src/main/java/gift/order/controller/OrderController.java
@@ -4,10 +4,17 @@ import gift.order.domain.CreateOrderRequest;
 import gift.order.domain.OrderCreateResponse;
 import gift.order.service.OrderService;
 import gift.util.CommonResponse;
+import gift.util.annotation.JwtAuthenticated;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.annotation.Nullable;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "OrderController", description = "주문 관련 API")
@@ -20,16 +27,20 @@ public class OrderController {
         this.orderService = orderService;
     }
 
-//    @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다.")
-//    @PostMapping("/orders")
-//    public ResponseEntity<?> createOrder(
-//            @RequestBody CreateOrderRequest createOrderRequest,
-//            @Parameter(description = "액세스 토큰") @RequestHeader String accessToken) {
-//        OrderCreateResponse order = orderService.createOrder(createOrderRequest, accessToken);
-//        return ResponseEntity.ok().body(new CommonResponse<>(
-//                order,
-//                "주문 생성 성공",
-//                true
-//        ));
-//    }
+    @JwtAuthenticated
+    @Operation(summary = "주문 생성", description = "새로운 주문을 생성합니다.")
+    @GetMapping("/orders")
+    public ResponseEntity<?> createOrder(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "createdAt,desc") String sort) {
+
+        String[] sortParams = sort.split(",");
+        Sort sorting = Sort.by(Sort.Direction.fromString(sortParams[1]), sortParams[0]);
+        Pageable pageable = PageRequest.of(page, size, sorting);
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Long userId = Long.valueOf(authentication.getName());
+
+        return ResponseEntity.ok(orderService.getOrders(userId, pageable));
+    }
 }

--- a/src/main/java/gift/order/domain/Order.java
+++ b/src/main/java/gift/order/domain/Order.java
@@ -14,6 +14,7 @@ public class Order {
     private Long id;
 
     private Long userId;
+    private Long productId;
     private Long optionId;
     private Long quantity;
     private String message;
@@ -21,10 +22,12 @@ public class Order {
 
     private Boolean isReceipt;
 
-    private final LocalDateTime orderDateTime = LocalDateTime.now();
+
+    private final LocalDateTime createdAt = LocalDateTime.now();
 
     public Order(Long userId, PaymentRequest request) {
         this.userId = userId;
+        this.productId = request.getProductId();
         this.optionId = request.getOptionId();
         this.quantity = request.getQuantity();
         this.message = request.getMessage();
@@ -41,9 +44,45 @@ public class Order {
                 id,
                 optionId,
                 quantity,
-                orderDateTime.toString(),
+                createdAt.toString(),
                 message,
                 true
         );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public Long getOptionId() {
+        return optionId;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+    public Boolean getReceipt() {
+        return isReceipt;
+    }
+
+    public LocalDateTime getOrderDateTime() {
+        return createdAt;
     }
 }

--- a/src/main/java/gift/order/domain/OrderListResponse.java
+++ b/src/main/java/gift/order/domain/OrderListResponse.java
@@ -3,22 +3,22 @@ package gift.order.domain;
 import java.util.List;
 
 public class OrderListResponse {
-    private List<OrderResponse> products;
+    private List<OrderResponse> contents;
     private int number;
     private long totalElement;
     private int size;
     private boolean last;
 
     public OrderListResponse(List<OrderResponse> products, int number, long totalElement, int size, boolean last) {
-        this.products = products;
+        this.contents = products;
         this.number = number;
         this.totalElement = totalElement;
         this.size = size;
         this.last = last;
     }
 
-    public List<OrderResponse> getProducts() {
-        return products;
+    public List<OrderResponse> getContents() {
+        return contents;
     }
 
     public int getNumber() {

--- a/src/main/java/gift/order/domain/OrderListResponse.java
+++ b/src/main/java/gift/order/domain/OrderListResponse.java
@@ -1,0 +1,39 @@
+package gift.order.domain;
+
+import java.util.List;
+
+public class OrderListResponse {
+    private List<OrderResponse> products;
+    private int number;
+    private long totalElement;
+    private int size;
+    private boolean last;
+
+    public OrderListResponse(List<OrderResponse> products, int number, long totalElement, int size, boolean last) {
+        this.products = products;
+        this.number = number;
+        this.totalElement = totalElement;
+        this.size = size;
+        this.last = last;
+    }
+
+    public List<OrderResponse> getProducts() {
+        return products;
+    }
+
+    public int getNumber() {
+        return number;
+    }
+
+    public long getTotalElement() {
+        return totalElement;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public boolean isLast() {
+        return last;
+    }
+}

--- a/src/main/java/gift/order/domain/OrderResponse.java
+++ b/src/main/java/gift/order/domain/OrderResponse.java
@@ -1,0 +1,68 @@
+package gift.order.domain;
+
+public class OrderResponse {
+    private Long id;
+    private Long productId;
+    private String name;
+    private String imageUrl;
+    private Long optionId;
+    private Long count;
+    private Long price;
+    private String orderDateTime;
+    private String message;
+    private boolean success;
+
+    public OrderResponse(Long id, Long productId, String name, Long optionId, Long count, String imageUrl,Long price, String orderDateTime, String message, boolean success) {
+        this.id = id;
+        this.productId = productId;
+        this.name = name;
+        this.imageUrl = imageUrl;
+        this.optionId = optionId;
+        this.count = count;
+        this.price = price;
+        this.orderDateTime = orderDateTime;
+        this.message = message;
+        this.success = success;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public Long getOptionId() {
+        return optionId;
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    public Long getPrice() {
+        return price;
+    }
+
+    public String getOrderDateTime() {
+        return orderDateTime;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+}

--- a/src/main/java/gift/order/repository/OrderJpaRepository.java
+++ b/src/main/java/gift/order/repository/OrderJpaRepository.java
@@ -1,9 +1,12 @@
 package gift.order.repository;
 
 import gift.order.domain.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface OrderJpaRepository extends JpaRepository<Order, Long> {
+    Page<Order> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/gift/order/repository/OrderRepository.java
+++ b/src/main/java/gift/order/repository/OrderRepository.java
@@ -1,9 +1,14 @@
 package gift.order.repository;
 
 import gift.order.domain.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 
 public interface OrderRepository {
     public Order save(Order order);
 
     public Order findById(Long id);
+
+    Page<Order> findByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/gift/order/repository/OrderRepositoryImpl.java
+++ b/src/main/java/gift/order/repository/OrderRepositoryImpl.java
@@ -1,6 +1,8 @@
 package gift.order.repository;
 
 import gift.order.domain.Order;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -21,5 +23,9 @@ public class OrderRepositoryImpl implements OrderRepository {
         return orderJpaRepository.findById(id).orElseThrow(
                 () -> new RuntimeException("Order not found")
         );
+    }
+
+    public Page<Order> findByUserId(Long userId, Pageable pageable) {
+        return orderJpaRepository.findByUserId(userId, pageable);
     }
 }

--- a/src/main/java/gift/order/service/OrderService.java
+++ b/src/main/java/gift/order/service/OrderService.java
@@ -1,14 +1,25 @@
 package gift.order.service;
 
-import gift.order.domain.CreateOrderRequest;
 import gift.order.domain.Order;
-import gift.order.domain.OrderCreateResponse;
+import gift.order.domain.OrderListResponse;
+import gift.order.domain.OrderResponse;
 import gift.order.repository.OrderRepository;
 import gift.payment.domain.PaymentRequest;
 import gift.payment.domain.PaymentResponse;
+import gift.product.application.ProductService;
 import gift.product.application.WishListService;
+import gift.product.domain.Product;
+import gift.product.domain.ProductListResponse;
+import gift.product.domain.ProductResponse;
 import gift.user.application.KakaoOauthService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 
 @Service
 public class OrderService {
@@ -17,12 +28,14 @@ public class OrderService {
 
     private final WishListService wishListService;
     private final KakaoOauthService kakaoOauthService;
+    private final ProductService productService;
 
-    public OrderService(OrderRepository orderRepository, KakaoAllimService allimService, WishListService wishListService, KakaoOauthService kakaoOauthService) {
+    public OrderService(OrderRepository orderRepository, KakaoAllimService allimService, WishListService wishListService, KakaoOauthService kakaoOauthService, ProductService productService) {
         this.orderRepository = orderRepository;
         this.allimService = allimService;
         this.wishListService = wishListService;
         this.kakaoOauthService = kakaoOauthService;
+        this.productService = productService;
     }
 
     public PaymentResponse createOrder(Long userId, PaymentRequest request) {
@@ -32,5 +45,39 @@ public class OrderService {
         // 주문 생성
         Order order = orderRepository.save(new Order(userId, request));
         return order.toOrderCreateResponse();
+    }
+
+    public OrderListResponse getOrders(Long userId, Pageable pageable) {
+        Page<Order> orders = orderRepository.findByUserId(userId, pageable);
+        List<Long> productIds = orders.getContent().stream()
+                .map(Order::getProductId)
+                .collect(Collectors.toList());
+        Map<Long, Product> products = productService.getProductsByIds(productIds);
+
+        List<OrderResponse> orderResponses = orders.getContent().stream()
+                .map(order -> {
+                    Product product = products.get(order.getProductId());
+                    return new OrderResponse(
+                            order.getId(),
+                            order.getProductId(),
+                            product.getName(),
+                            order.getOptionId(),
+                            order.getQuantity(),
+                            product.getImageUrl(),
+                            product.getPrice(),
+                            order.getOrderDateTime().toString(),
+                            order.getMessage(),
+                            true
+                    );
+                })
+                .collect(Collectors.toList());
+
+        return new OrderListResponse(
+                orderResponses,
+                orders.getNumber(),
+                orders.getTotalElements(),
+                orders.getNumberOfElements(),
+                orders.isLast()
+        );
     }
 }

--- a/src/main/java/gift/product/application/ProductService.java
+++ b/src/main/java/gift/product/application/ProductService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 @Service
 public class ProductService {
@@ -109,6 +110,10 @@ public class ProductService {
         return productOptions.stream()
                 .map(productOption -> new ProductOptionData(productOption.getId(), productOption.getName(), productOption.getQuantity(), productOption.getProduct().getId()))
                 .toList();
+    }
+
+    public Map<Long, Product> getProductsByIds(List<Long> productIds) {
+        return productRepository.getProductsByIds(productIds);
     }
 
 

--- a/src/main/java/gift/product/infra/ProductJpaRepository.java
+++ b/src/main/java/gift/product/infra/ProductJpaRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 @Repository
@@ -14,4 +16,6 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
     Page<Product> findAll(Pageable pageable);
 
     Page<Product> findByCategoryId(Long categoryId, Pageable pageable);
+
+    List<Product> findByIdIn(List<Long> productIds);
 }

--- a/src/main/java/gift/product/infra/ProductRepository.java
+++ b/src/main/java/gift/product/infra/ProductRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Repository
 public class ProductRepository {
@@ -63,5 +65,12 @@ public class ProductRepository {
                 .orElseThrow(() -> new ProductException(ErrorCode.PRODUCT_OPTION_NOT_FOUND));
         productOption.decreaseQuantity(quantity);
         productOptionJpaRepository.save(productOption);
+    }
+
+
+    public Map<Long, Product> getProductsByIds(List<Long> productIds) {
+        List<Product> products = productJpaRepository.findByIdIn(productIds);
+        return products.stream()
+                .collect(Collectors.toMap(Product::getId, product -> product));
     }
 }

--- a/src/main/resources/db/schema.sql
+++ b/src/main/resources/db/schema.sql
@@ -65,12 +65,13 @@ CREATE TABLE orders
 (
     id              BIGINT AUTO_INCREMENT PRIMARY KEY,
     user_id         BIGINT NOT NULL,
+    product_id      BIGINT NOT NULL,
     option_id       BIGINT NOT NULL,
     quantity        BIGINT NOT NULL,
     message         VARCHAR(255),
     is_receipt    BOOLEAN   DEFAULT FALSE,
     phone_number    VARCHAR(255),
-    order_date_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     FOREIGN KEY (user_id) REFERENCES users (user_id),
     FOREIGN KEY (option_id) REFERENCES product_option (id)
 );


### PR DESCRIPTION
안녕하세요 멘토님 :D
CICD 관련해서는 기존에 ecs 배포했을 때는 git action을 활용해서 매번 구축을 했었는데, 이번에는 ec2에 배포해도 충분하다고 판단하였고 잦은 수정이 없을 것 같아 따로 구현하진 않았습니다! 다만, 프론트에서 git page(?)에 배포한다는 소식을 전달받고 https 통신이 필요하여, alb에 도메인 사서 붙이고 인증서 발급받으면 바로 해결되겠지만, 돈이 없는 관계로 ec2에 nginx를 띄우고, duckdns에서 무료 dns를 발급받고 certbot, openssl, Let's Encrypt활용해서 https를 지원하도록 설정해주었습니다!

step3의 요구사항은 포인트였는데, step2에서 이미 진행하여 팀내 협업 과정에서 필요했던 API 수정 작업으로 PR올립니다!


### 변경사항
- 오더 조회 API 명세 수정했습니다.
- 페이지네이션 적용이 안되어있어서 구현했습니다.

### 질문사항
**1. ProductId와 OptionId**
조금 애매했던 점은, 오더를 생성하거나 결제처리하든, 상품을 조회하든 할 때 클라이언트에게 제공하는 optionId가 아무리 unique하다고 해도 productId와 함께 제공해야하지 않느냐는 생각을 했습니다. JPA를 통해서 optionId를 통해 productId를 가져올 경우에 안정성이 더 떨어지지 않느냐는 생각을 했습니다. 따라서 optionId만이 아닌 productId도 매번 전달하고/받아야 한다 라고 생각했는데 잘못된 생각인지 궁금합니다!

팀원들 일부는 order 엔티티 자체에 productId가 없는 구성원이 있었습니다. optionId로 productId를 찾을 수 있기에 그렇다는 점은 이해하나, 상품에 대한 옵션이기에, 상품 id도 필요하며, 오더 생성시에 해당 optionId가 해당 상품(productId)의 옵션이 맞는지 validation하는 과정과 같이 추가적인 장치가 필요하다고 생각했습니다. 또한, 원치않게 사용자가 의도하지 않은대로 동작할 가능성을 보아 두가지를 저장하는게 안정성이든 로깅 측면에서 더 나을거라 생각했습니다.

흠... 잘못된 생각인지 잘 모르겠습니다! 어떤 사람은 그냥 "jpa로 가져올건데 뭐 괜찮지않아?"라고 하셔서 틀린 말은 또 아닌거같고 그렇네요.

**2. 지난 오더 조회 N+1 문제**
지난 오더 조회 부분에서 Order 도메인에 imageUrl이 없어 Product을 참조해야하는 문제가 발생합니다. 이렇게 되면 N개의 상품이면 N번의 쿼리가 나가게 되네요. (N+1문제?) 따라서 한번의 쿼리로 필요한 id들을 모두 가져와 조회하는 방식으로 구현하였습니다만, 좋은 방법인지 궁금합니다. fetch join을 활용하나요? 

만약에 지금당장은 두개의 테이블이지만 몇개는 더 늘어난다면 그에 대응하는 해결책도 있을 것 같습니다. 이에 관련해서도 궁금합니다. 제가 더 알아보겠습니다!
