### PR TITLE
전남대 BE_강명덕 6주차 과제 (3단계)

### DIFF
--- a/src/main/java/gift/member/controller/MemberController.java
+++ b/src/main/java/gift/member/controller/MemberController.java
@@ -1,10 +1,12 @@
 package gift.member.controller;
 
+import gift.auth.LoginMember;
 import gift.auth.dto.LoginReqDto;
 import gift.auth.dto.LoginResDto;
 import gift.auth.dto.RegisterResDto;
 import gift.auth.service.AuthService;
 import gift.common.annotation.AllowAnonymous;
+import gift.member.dto.MemberPointsResDto;
 import gift.member.dto.MemberReqDto;
 import gift.member.dto.MemberResDto;
 import gift.member.service.MemberService;
@@ -62,6 +64,15 @@ public class MemberController {
             })
     public ResponseEntity<List<MemberResDto>> getMembers() {
         return ResponseEntity.ok(memberService.getMembers());
+    }
+
+    @GetMapping("/points")
+    @Operation(summary = "포인트 조회", description = "회원의 포인트를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "포인트 조회 성공"),
+            })
+    public ResponseEntity<MemberPointsResDto> getMemberPoints(@LoginMember MemberResDto memberDto) {
+        return ResponseEntity.ok(memberService.getMemberPoints(memberDto));
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/gift/member/dto/MemberPointsResDto.java
+++ b/src/main/java/gift/member/dto/MemberPointsResDto.java
@@ -1,0 +1,6 @@
+package gift.member.dto;
+
+public record MemberPointsResDto(
+        Integer points
+) {
+}

--- a/src/main/java/gift/member/entity/Member.java
+++ b/src/main/java/gift/member/entity/Member.java
@@ -12,6 +12,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import org.hibernate.annotations.ColumnDefault;
 
 @Entity
 public class Member {
@@ -26,6 +27,10 @@ public class Member {
     @Column(nullable = false)
     private String password;
 
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    private Integer points;
+
     @Column
     private String kakaoAccessToken;
 
@@ -35,6 +40,7 @@ public class Member {
     public Member(String email, String password) {
         this.email = email;
         this.password = password;
+        this.points = 0;
     }
 
     protected Member() {
@@ -50,6 +56,18 @@ public class Member {
 
     public String getPassword() {
         return password;
+    }
+
+    public Integer getPoints() {
+        return points;
+    }
+
+    public void addPoints(Integer points) {
+        this.points += points;
+    }
+
+    public void usePoints(Integer points) {
+        this.points -= points;
     }
 
     public List<WishList> getWishLists() {

--- a/src/main/java/gift/member/exception/MemberErrorCode.java
+++ b/src/main/java/gift/member/exception/MemberErrorCode.java
@@ -11,6 +11,8 @@ public enum MemberErrorCode implements ErrorCode {
     MEMBER_CREATE_FAILED("M003", HttpStatus.INTERNAL_SERVER_ERROR, "회원 생성에 실패했습니다."),
     MEMBER_UPDATE_FAILED("M004", HttpStatus.INTERNAL_SERVER_ERROR, "회원 정보 수정에 실패했습니다."),
     MEMBER_DELETE_FAILED("M005", HttpStatus.INTERNAL_SERVER_ERROR, "회원 삭제에 실패했습니다."),
+
+    MEMBER_NOT_ENOUGH_POINT("M006", HttpStatus.BAD_REQUEST, "포인트가 부족합니다."),
     ;
 
     private final String code;

--- a/src/main/java/gift/member/exception/MemberNotEnoughPointException.java
+++ b/src/main/java/gift/member/exception/MemberNotEnoughPointException.java
@@ -1,0 +1,12 @@
+package gift.member.exception;
+
+import gift.common.exception.BusinessException;
+
+public class MemberNotEnoughPointException extends BusinessException {
+
+    public static BusinessException EXCEPTION = new MemberNotEnoughPointException();
+
+    public MemberNotEnoughPointException() {
+        super(MemberErrorCode.MEMBER_NOT_ENOUGH_POINT);
+    }
+}

--- a/src/main/java/gift/member/points/PercentageBasedPointsStrategy.java
+++ b/src/main/java/gift/member/points/PercentageBasedPointsStrategy.java
@@ -1,0 +1,20 @@
+package gift.member.points;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class PercentageBasedPointsStrategy implements PointsStrategy {
+
+    private final Integer FIVE_PERCENT = 5;
+
+    private final Integer percentage;
+
+    public PercentageBasedPointsStrategy() {
+        this.percentage = FIVE_PERCENT;
+    }
+
+    @Override
+    public Integer calculatePointsToAdd(Integer price) {
+        return price * percentage / 100;
+    }
+}

--- a/src/main/java/gift/member/points/PointsStrategy.java
+++ b/src/main/java/gift/member/points/PointsStrategy.java
@@ -1,0 +1,6 @@
+package gift.member.points;
+
+public interface PointsStrategy {
+
+    Integer calculatePointsToAdd(Integer price);
+}

--- a/src/main/java/gift/order/dto/OrderReqDto.java
+++ b/src/main/java/gift/order/dto/OrderReqDto.java
@@ -3,6 +3,7 @@ package gift.order.dto;
 public record OrderReqDto(
         Long optionId,
         Integer quantity,
+        Integer points,
         String message
 ) {
 

--- a/src/testFixtures/java/gift/member/MemberFixture.java
+++ b/src/testFixtures/java/gift/member/MemberFixture.java
@@ -6,7 +6,9 @@ import gift.member.entity.Member;
 public class MemberFixture {
 
     public static Member createMember() {
-        return new Member("abc123@test.com", "1234");
+        Member member = new Member("abc123@test.com", "1234");
+        member.addPoints(10000);
+        return member;
     }
 
     public static Member createMember(String email, String password) {

--- a/src/testFixtures/java/gift/order/OrderFixture.java
+++ b/src/testFixtures/java/gift/order/OrderFixture.java
@@ -11,7 +11,7 @@ public class OrderFixture {
         return new Order(member, option, quantity, message);
     }
 
-    public static OrderReqDto createOrderReqDto(Long optionId, Integer quantity, String message) {
-        return new OrderReqDto(optionId, quantity, message);
+    public static OrderReqDto createOrderReqDto(Long optionId, Integer quantity, Integer points, String message) {
+        return new OrderReqDto(optionId, quantity, points, message);
     }
 }

--- a/src/testFixtures/java/gift/product/ProductFixture.java
+++ b/src/testFixtures/java/gift/product/ProductFixture.java
@@ -23,6 +23,10 @@ public class ProductFixture {
         return product;
     }
 
+    public static Product createProduct(String name, Integer price) {
+        return new Product(name, price, "imageUrl", CategoryFixture.createCategory("category"));
+    }
+
     public static Product createProduct(String name, Integer price, String imageUrl) {
         return new Product(name, price, imageUrl, null);
     }


### PR DESCRIPTION
## 코드를 작성하며 어려웠던 점
- 포인트 적립 전략이 추후 바뀌게 된다면 어떤 식으로 대응해야 할지 생각해보며 구글링을 했습니다. 구현체가 두 개 이상 존재하는 경우 주입받을 빈을 선택할 수 있도록 `@Qualifier`를 사용해 적용하려 합니다.

## 코드 리뷰 시, 멘토님이 중점적으로 리뷰해줬으면 하는 부분
- [MemberService 커밋 - 3ab5c27](https://github.com/kakao-tech-campus-2nd-step2/spring-gift-point/commit/1354ed1f6309f56680e771fa2474ff5ce9044c46)에서 `processOrderPoints` 로직을 작성할 때 **포인트 차감**과 **포인트 적립**을 한 트랜잭션 안에서 수행하도록 작성했습니다. 주문 시 회원의 포인트 처리 로직을 한 트랜잭션에 담는 것이 괜찮다고 생각하는데, 이런식으로 작성해도 괜찮은 것인지 궁금합니다!